### PR TITLE
[WC-362] Fix localized date handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4789,10 +4789,9 @@
       "optional": true
     },
     "date-format": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
-      "integrity": "sha1-YV6CjiM90aubua4JUODOzPpuytg=",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
+      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w=="
     },
     "date-now": {
       "version": "0.1.4",
@@ -11259,6 +11258,12 @@
         "streamroller": "0.7.0"
       },
       "dependencies": {
+        "date-format": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
+          "integrity": "sha1-YV6CjiM90aubua4JUODOzPpuytg=",
+          "dev": true
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -17318,6 +17323,12 @@
         "readable-stream": "^2.3.0"
       },
       "dependencies": {
+        "date-format": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
+          "integrity": "sha1-YV6CjiM90aubua4JUODOzPpuytg=",
+          "dev": true
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
   "dependencies": {
     "ace-builds": "^1.4.12",
     "classnames": "^2.2.6",
+    "date-format": "^3.0.0",
     "deep-equal": "^2.0.5",
     "deepmerge": "^2.1.1",
     "element-resize-detector": "^1.1.14",

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -2,6 +2,8 @@ import { ReactChild, createElement } from "react";
 import deepMerge from "deepmerge";
 import { Datum } from "plotly.js";
 import { Container, Data } from "./namespaces";
+import { Store } from "redux";
+import { asString } from "date-format";
 import SeriesProps = Data.SeriesProps;
 import SeriesData = Data.SeriesData;
 import EventProps = Data.EventProps;
@@ -11,7 +13,6 @@ import FetchedData = Data.FetchedData;
 import FetchDataOptions = Data.FetchDataOptions;
 import FetchByXPathOptions = Data.FetchByXPathOptions;
 import FetchByIdOptions = Data.FetchByGuidsOptions;
-import { Store } from "redux";
 import MxMetaObject = mendix.lib.MxMetaObject;
 
 type MxO = mendix.lib.MxObject;
@@ -462,7 +463,10 @@ export const getAttributeValue = (mxObject: MxO, attribute: string): Datum => {
         }
     }
     if (valueObject.isDate(attributeName)) {
-        return new Date(valueObject.get(attributeName) as number).toISOString();
+        const dateValue: number = valueObject.get(attributeName) as number;
+
+        // Converts the timestamp to ISO-8601
+        return asString(new Date(dateValue));
     }
     if (valueObject.isEnum(attributeName)) {
         const enumValue = valueObject.get(attributeName) as string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
     "strictFunctionTypes": false,
     "skipLibCheck": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "allowSyntheticDefaultImports": true
   },
   "exclude": [
     "dist/",

--- a/typings/date-format.d.ts
+++ b/typings/date-format.d.ts
@@ -1,0 +1,3 @@
+declare module "date-format" {
+    export function asString(date: Date): string;
+}


### PR DESCRIPTION
Current charts handle date always as UTC time, due to a conversion to ISOString in `data.ts`. This PR handles now dates in the correct way keeping the timezone assigned in the original data and just formating the date to ISO-8601 (2021-04-22T18:00:00.000Z) before send it to plotly.