### PR TITLE
chore: prepare release for MX 9.6

### DIFF
--- a/CHANGELOG.anychart.md
+++ b/CHANGELOG.anychart.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [3.0.0] - 2021-09-28
+
 ### Added
-- We added new large icons
 - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [1.3.7] - 2021-08-04

--- a/CHANGELOG.charts.md
+++ b/CHANGELOG.charts.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [2.0.0] - 2021-09-28
+
 ### Added
-- We added new large icons
 - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [1.4.12] - 2021-08-04

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "charts",
-  "version": "1.4.11",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/AnyChart/package.xml
+++ b/src/AnyChart/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="AnyChart" version="2.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="AnyChart" version="3.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="AnyChart/AnyChart.xml"/>
         </widgetFiles>


### PR DESCRIPTION
- Update changelogs
- Bump version of anychart used to create the release for MX 9.6