### PR TITLE
chore: bump version for module change in model

### DIFF
--- a/CHANGELOG.anychart.md
+++ b/CHANGELOG.anychart.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [3.0.1] - 2021-09-28
+
+### Changed
+- We started to track the module version in a constant document inside the module.
+
 ## [3.0.0] - 2021-09-28
 
 ### Added

--- a/src/AnyChart/package.xml
+++ b/src/AnyChart/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="AnyChart" version="3.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="AnyChart" version="3.0.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="AnyChart/AnyChart.xml"/>
         </widgetFiles>


### PR DESCRIPTION
I added a constant document in the module, so users know which version of a module they use. I removed the outdated empty folder with version inside the module. Therefore, the version needs to be bumped for release.